### PR TITLE
AWS Agent enabled and Check if already installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Available variables are listed below, along with default values (see `defaults/m
 
 URL from which inspector installer will be downloaded, and temporary directory where installer will be stored.
 
-    awsagent_state: started
     awsagent_enabled: yes
 
 Control the `awsagent` service; by default, for Amazon Inspector to work correctly, you must have `awsagent` running on any server you want inspected.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,6 @@
 ---
 aws_inspector_url: "https://d1wk0tztpsntt1.cloudfront.net/linux/latest/install"
 aws_inspector_installer_dest: /tmp/aws_inspector_agent_installer
-
-awsagent_state: started
-awsagent_enabled: yes
-
 aws_inspector_role_test_mode: no
+
+awsagent_enabled: yes

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: restart awsagent
-  service: name=awsagent state=restarted
+  service: 
+    name: awsagent 
+    state: restarted
+  when: awsagent_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,31 @@
 ---
+- name: Check if AWS Inspector already installed
+  stat:
+    path: "{{ aws_inspector_installer_dest }}"
+  register: aws_inspector_result
+
 - name: Download AWS Inspector agent installer.
   get_url:
     url: "{{ aws_inspector_url }}"
     dest: "{{ aws_inspector_installer_dest }}"
+  when: not aws_inspector_result.stat.exists
 
 - name: Ensure AWS Inspector agent is installed.
   command: bash "{{ aws_inspector_installer_dest }}"
   args:
     creates: "/etc/init.d/awsagent"
-  when: aws_inspector_role_test_mode != True
+  when: not aws_inspector_role_test_mode and not aws_inspector_result.stat.exists
 
 - name: Ensure awsagent service is running.
   service:
     name: awsagent
-    state: "{{ awsagent_state }}"
+    state: started
     enabled: yes
-  when: aws_inspector_role_test_mode != True
+  when: not aws_inspector_role_test_mode and awsagent_enabled
+
+- name: Ensure awsagent service is not running.
+  service:
+    name: awsagent
+    state: stopped
+    enabled: no
+  when: not aws_inspector_role_test_mode and not awsagent_enabled


### PR DESCRIPTION
Add a checker to validate if awsagent already instaled
If already instaled do not try download and install again
Fix variable awsagent_enabled