### PR TITLE
Add proxy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ There is also a handler, `restart awsagent`, which can be used to restart the ag
 
 Set this to `true` if testing or using this role outside of an EC2 instance (e.g. if testing in CI or building a server in a different cloud environment).
 
+There is also support for proxy configuration:
+
+    aws_inspector_proxy_enabled: false
+    aws_inspector_https_proxy: 127.0.0.1:8080
+    aws_inspector_http_proxy: 127.0.0.1:8080
+    aws_inspector_no_proxy: 169.254.169.254
+
+Set `aws_inspector_proxy_enabled` to `true` and configure the rest of `*_proxy` variables to create a `/etc/init.d/awsagent.env` file that will enable proxy support.
+
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,8 @@ awsagent_state: started
 awsagent_enabled: true
 
 aws_inspector_role_test_mode: false
+
+aws_inspector_proxy_enabled: false
+aws_inspector_https_proxy: 127.0.0.1:8080
+aws_inspector_http_proxy: 127.0.0.1:8080
+aws_inspector_no_proxy: 169.254.169.254

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,16 @@
     url: "{{ aws_inspector_url }}"
     dest: "{{ aws_inspector_installer_dest }}"
 
+- name: Configure proxy if necessary
+  template:
+    src: awsagent.env.j2
+    dest: /etc/init.d/awsagent.env
+    owner: root
+    group: root
+    mode: '0644'
+  notify: restart awsagent
+  when: aws_inspector_proxy_enabled
+
 - name: Ensure AWS Inspector agent is installed.
   command: bash "{{ aws_inspector_installer_dest }}"
   args:

--- a/templates/awsagent.env.j2
+++ b/templates/awsagent.env.j2
@@ -1,0 +1,3 @@
+export https_proxy={{ aws_inspector_https_proxy }}
+export http_proxy={{ aws_inspector_http_proxy }}
+export no_proxy={{ aws_inspector_no_proxy }}


### PR DESCRIPTION
This change enables proxy configuration for environments which cannot access the AWS Inspector servers.

Configuration steps are detailed in Amazon's documentation: https://docs.aws.amazon.com/inspector/latest/userguide/inspector_agents-on-linux.html#inspector-agent-proxy-linux

The file `/etc/init.d/awsagent.env` will only be created if `aws_inspector_proxy_enabled` variable is set to `true`, so it should not configure a proxy by default.

Let me know if you have any doubts. Thanks.