### PR TITLE
Added region protection

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,19 @@ aws_inspector_proxy_enabled: false
 aws_inspector_https_proxy: 127.0.0.1:8080
 aws_inspector_http_proxy: 127.0.0.1:8080
 aws_inspector_no_proxy: 169.254.169.254
+
+regions: 
+  - us-east-2
+  - us-east-1
+  - us-west-1
+  - us-west-2
+  - ap-south-1
+  - ap-northeast-2
+  - ap-southeast-2
+  - ap-northeast-1
+  - eu-central-1
+  - eu-west-1
+  - eu-west-2
+  - eu-north-1
+  - gov-us-east-1
+  - gov-us-east-2

--- a/tasks/inspector.yml
+++ b/tasks/inspector.yml
@@ -1,0 +1,28 @@
+---
+- name: Download AWS Inspector agent installer.
+  get_url:
+    url: "{{ aws_inspector_url }}"
+    dest: "{{ aws_inspector_installer_dest }}"
+
+- name: Configure proxy if necessary
+  template:
+    src: awsagent.env.j2
+    dest: /etc/init.d/awsagent.env
+    owner: root
+    group: root
+    mode: '0644'
+  notify: restart awsagent
+  when: aws_inspector_proxy_enabled
+
+- name: Ensure AWS Inspector agent is installed.
+  command: bash "{{ aws_inspector_installer_dest }}"
+  args:
+    creates: "/etc/init.d/awsagent"
+  when: not aws_inspector_role_test_mode
+
+- name: Ensure awsagent service is running.
+  service:
+    name: awsagent
+    state: "{{ awsagent_state }}"
+    enabled: true
+  when: not aws_inspector_role_test_mode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,28 +1,9 @@
 ---
-- name: Download AWS Inspector agent installer.
-  get_url:
-    url: "{{ aws_inspector_url }}"
-    dest: "{{ aws_inspector_installer_dest }}"
+- name: 'gather amazon.aws.ec2_metadata_facts'
+  ec2_metadata_facts:
 
-- name: Configure proxy if necessary
-  template:
-    src: awsagent.env.j2
-    dest: /etc/init.d/awsagent.env
-    owner: root
-    group: root
-    mode: '0644'
-  notify: restart awsagent
-  when: aws_inspector_proxy_enabled
-
-- name: Ensure AWS Inspector agent is installed.
-  command: bash "{{ aws_inspector_installer_dest }}"
-  args:
-    creates: "/etc/init.d/awsagent"
-  when: not aws_inspector_role_test_mode
-
-- name: Ensure awsagent service is running.
-  service:
-    name: awsagent
-    state: "{{ awsagent_state }}"
-    enabled: true
-  when: not aws_inspector_role_test_mode
+- name: "install inspector"
+  include: inspector.yml
+  with_items: regions
+  when: ansible_ec2_placement_region in regions
+  


### PR DESCRIPTION
This PR has some changes to make sure that AWS Inspector does not try to install within a region that is not supported yet. 

https://docs.aws.amazon.com/inspector/latest/userguide/inspector_supported_os_regions.html#inspector_supported-regions

